### PR TITLE
update badges to point to qgroom/bedbugs; explicitly mention globalbi…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Build Status](https://travis-ci.com/globalbioticinteractions/template-dataset.svg)](https://travis-ci.com/globalbioticinteractions/template-dataset) [![DOI](https://zenodo.org/badge/26293374.svg)](https://zenodo.org/badge/latestdoi/26293374) [![GloBI](https://api.globalbioticinteractions.org/interaction.svg?accordingTo=globi:globalbioticinteractions/template-dataset)](https://globalbioticinteractions.org/?accordingTo=globi:globalbioticinteractions/template-dataset) 
+[![Build Status](https://travis-ci.com/globalbioticinteractions/template-dataset.svg)](https://travis-ci.com/qgroom/bedbugs)  [![GloBI](https://api.globalbioticinteractions.org/interaction.svg?accordingTo=globi:qgroom/bedbugs)](https://globalbioticinteractions.org/?accordingTo=globi:qgroom/bedbugs) 
 
-To index data on bedbugs *Cimex lectularius* (Heteroptera: Cimicidae) via Globi
+To index data on bedbugs *Cimex lectularius* (Heteroptera: Cimicidae) via Global Biotic Interactions (GloBI, https://globalbioticinteractions.org) .
 
 Balvín, O., Munclinger, P., Kratochvíl, L. et al. Mitochondrial DNA and morphology show independent evolutionary histories of bedbug *Cimex lectularius* (Heteroptera: Cimicidae) on bats and humans. *Parasitol Res* **111**, 457–469 (2012). https://doi.org/10.1007/s00436-012-2862-5


### PR DESCRIPTION
…oticinteractions.org to enable discovery via GitHub search indexes.

Some minor updates to help GloBI find your transcribed data: the readme should contain an explicit mention of https://globalbioticinteractions.org for GitHub search to automatically include the bedbugs in GloBI's indexes. 

Thanks for helping to transcribe the interaction records, and please let me know if you have any idea to make it easier for others to follow your example.